### PR TITLE
fix: Unify how commands 'help' and 'version' work

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -37,6 +37,8 @@ enum State {
     STATE_DISPLAY_ROTATE,
     STATE_CONFIG_SHOW,
     STATE_CONFIG_SAVE,
+    STATE_PRINT_VERSION,
+    STATE_PRINT_HELP,
 };
 
 // For communication between core0/1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,9 +146,9 @@ void handleRepl() {
                 } else if (inputBuffer == "save") {
                     runtimeState.setCurrentState(STATE_CONFIG_SAVE);
                 } else if (inputBuffer == "version" ) {
-                    printFwVersion();
+                    runtimeState.setCurrentState(STATE_PRINT_VERSION);
                 } else if (inputBuffer == "help") {
-                    printHelp();
+                    runtimeState.setCurrentState(STATE_PRINT_HELP);
                 } else {
                     Serial.println("Unknown command. Type 'help' for available commands.");
                 }
@@ -439,6 +439,14 @@ void loop() {
         case STATE_CONFIG_SAVE:
             cfg.save();
             print("Notice", "Saved config");
+            runtimeState.setCurrentState(STATE_RETURN_TO_REPL);
+            break;
+        case STATE_PRINT_VERSION:
+            printFwVersion();
+            runtimeState.setCurrentState(STATE_RETURN_TO_REPL);
+            break;
+        case STATE_PRINT_HELP:
+            printHelp();
             runtimeState.setCurrentState(STATE_RETURN_TO_REPL);
             break;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,8 @@ void print(const char* header, const char *text, int durationMs = 0) {
 void printFwVersion(bool startup = false) {
     char *fwString = (char *)calloc(1, 255);
     snprintf(fwString, 255, "%s %lu", FW_VERSION, BUILD_DATE);
-    print("FW", fwString, 2000);
+    // Only delay the print on startup
+    print("FW", fwString, startup ? 2000 : 0);
     free(fwString);
     if (startup) {
         runtimeState.display()->printMessage("Presented by", "xboxresearch.com");


### PR DESCRIPTION
Now they both return to the REPL properly, aka. back to showing the actual ">> " prompt.